### PR TITLE
Fix exit alias and handshake fallback

### DIFF
--- a/bitchat/client.py
+++ b/bitchat/client.py
@@ -252,11 +252,11 @@ class BitchatClient:
                 import traceback
                 debug_println(f"[3] Traceback: {traceback.format_exc()}")
                 # Fallback to old key exchange
-                handshake_message = self.encryption_service.initiate_handshake(self.my_peer_id)
-                handshake_packet = create_bitchat_packet(
-                    self.my_peer_id, MessageType.KEY_EXCHANGE, handshake_message
+                key_data = self.encryption_service.get_combined_public_key_data()
+                key_packet = create_bitchat_packet(
+                    self.my_peer_id, MessageType.KEY_EXCHANGE, key_data
                 )
-                await self.send_packet(handshake_packet)
+                await self.send_packet(key_packet)
             
             # Wait a bit between packets
             await asyncio.sleep(0.5)

--- a/bitchat/user_input.py
+++ b/bitchat/user_input.py
@@ -26,7 +26,8 @@ async def handle_user_input(client: "BitchatClient", line: str):
         print_help()
         return
     
-    if line == "/exit":
+    cmd = line.strip()
+    if cmd in ["/exit", "/q"]:
         # Send leave notification if connected
         if client.client and client.client.is_connected:
             leave_packet = create_bitchat_packet(
@@ -34,7 +35,7 @@ async def handle_user_input(client: "BitchatClient", line: str):
             )
             await client.send_packet(leave_packet)
             await asyncio.sleep(0.1)  # Give time for the packet to send
-        
+
         await client.save_app_state()
         client.running = False
         return


### PR DESCRIPTION
## Summary
- allow `/q` as exit alias and strip whitespace before matching
- avoid starting handshakes with our own ID in fallback

## Testing
- `python3 test_identity_announcement.py`

------
https://chatgpt.com/codex/tasks/task_e_688d14c883848327818f9daa881712a8