### PR TITLE
Fix unconditional exit bug

### DIFF
--- a/bitchat/user_input.py
+++ b/bitchat/user_input.py
@@ -34,13 +34,13 @@ async def handle_user_input(client: "BitchatClient", line: str):
             )
             await client.send_packet(leave_packet)
             await asyncio.sleep(0.1)  # Give time for the packet to send
-        
-    try:
-        await client.save_app_state()
-    except Exception as e:
-        debug_println(f"[ERROR] Failed to save app state: {e}")
-    client.running = False
-    return
+
+        try:
+            await client.save_app_state()
+        except Exception as e:
+            debug_println(f"[ERROR] Failed to save app state: {e}")
+        client.running = False
+        return
     
     if line.startswith("/name "):
         new_name = line[6:].strip()


### PR DESCRIPTION
## Summary
- fix unconditional exit when sending messages by scoping state-saving and shutdown inside `/exit`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5652fa648327a673e5b29788ce85