### PR TITLE
Fix unconditional exit bug

### DIFF
--- a/bitchat/handlers.py
+++ b/bitchat/handlers.py
@@ -28,7 +28,7 @@ from .protocol import (
     should_send_ack,
     unpad_message,
 )
-from .terminal_ux import format_message_display, PrivateDM
+from .terminal_ux import format_message_display, PrivateDM, Channel
 
 if TYPE_CHECKING:
     from .client import BitchatClient
@@ -528,12 +528,22 @@ async def handle_leave(client: "BitchatClient", packet: BitchatPacket):
         # Channel leave
         channel = payload_str
         sender_nick = client.peers.get(packet.sender_id_str, Peer()).nickname or packet.sender_id_str
-        
-        if isinstance(client.chat_context.current_mode, Channel) and \
-           client.chat_context.current_mode.name == channel:
-            print(f"\r\033[K\033[90m« {sender_nick} left {channel}\033[0m\n> ", end='', flush=True)
-        
-        debug_println(f"[<-- RECV] {sender_nick} left channel {channel}")
+
+        if channel in client.chat_context.active_channels:
+            if (
+                isinstance(client.chat_context.current_mode, Channel)
+                and client.chat_context.current_mode.name == channel
+            ):
+                print(
+                    f"\r\033[K\033[90m« {sender_nick} left {channel}\033[0m\n> ",
+                    end='',
+                    flush=True,
+                )
+            debug_println(f"[<-- RECV] {sender_nick} left channel {channel}")
+        else:
+            debug_println(
+                f"[<-- RECV] {sender_nick} left unjoined channel {channel}, ignoring"
+            )
     else:
         # Peer disconnect
         disconnected_peer = client.peers.pop(packet.sender_id_str, None)

--- a/bitchat/user_input.py
+++ b/bitchat/user_input.py
@@ -34,13 +34,13 @@ async def handle_user_input(client: "BitchatClient", line: str):
             )
             await client.send_packet(leave_packet)
             await asyncio.sleep(0.1)  # Give time for the packet to send
-        
-    try:
-        await client.save_app_state()
-    except Exception as e:
-        debug_println(f"[ERROR] Failed to save app state: {e}")
-    client.running = False
-    return
+
+        try:
+            await client.save_app_state()
+        except Exception as e:
+            debug_println(f"[ERROR] Failed to save app state: {e}")
+        client.running = False
+        return
     
     if line.startswith("/name "):
         new_name = line[6:].strip()


### PR DESCRIPTION
## Summary
- fix unconditional exit when sending messages by scoping state-saving and shutdown inside `/exit`
- ignore channel leave notifications for channels the user hasn't joined

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5652fa648327a673e5b29788ce85